### PR TITLE
feat: support course modules in admin form

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -151,18 +151,22 @@ export const coursesAPI = {
     return apiRequest(`/courses/${id}`);
   },
 
-  create: async (courseData: any) => {
+  create: async (courseData: any, modules: any[] = []) => {
     return apiRequest('/courses', {
       method: 'POST',
-      body: JSON.stringify(courseData),
+      body: JSON.stringify({ ...courseData, modules }),
     });
   },
 
-  update: async (id: string, courseData: any) => {
+  update: async (id: string, courseData: any, modules: any[] = []) => {
     return apiRequest(`/courses/${id}`, {
       method: 'PUT',
-      body: JSON.stringify(courseData),
+      body: JSON.stringify({ ...courseData, modules }),
     });
+  },
+
+  getModules: async (courseId: string) => {
+    return apiRequest(`/courses/${courseId}/modules`);
   },
 
   delete: async (id: string) => {

--- a/src/pages/admin/AdminCourseForm.tsx
+++ b/src/pages/admin/AdminCourseForm.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Save, Plus, Trash2, Video, FileText, HelpCircle, Settings } 
 import { useCourseStore } from '../../store/courseStore';
 import { useCategoryStore } from '../../store/categoryStore';
 import { Course } from '../../types';
+import { coursesAPI } from '../../lib/api';
 import { QuizBuilder } from '../../components/admin/QuizBuilder';
 import { FileUploader } from '../../components/admin/FileUploader';
 import { ImageUploader } from '../../components/admin/ImageUploader';
@@ -79,6 +80,20 @@ export const AdminCourseForm: React.FC = () => {
     { value: 'pdf', label: 'Material PDF/PPT', icon: FileText, accept: '.pdf,application/pdf,.ppt,.pptx,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation' },
     { value: 'quiz', label: 'Questionário', icon: HelpCircle, accept: '' },
   ];
+
+  useEffect(() => {
+    if (isEditing && id) {
+      const fetchModules = async () => {
+        try {
+          const data = await coursesAPI.getModules(id);
+          setModules(data);
+        } catch (err) {
+          console.error('Erro ao carregar módulos:', err);
+        }
+      };
+      fetchModules();
+    }
+  }, [isEditing, id]);
   
 
   
@@ -109,25 +124,25 @@ export const AdminCourseForm: React.FC = () => {
   
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!validateForm()) {
       setActiveTab('basic'); // Voltar para a aba básica se houver erros
       return;
     }
-    
+
     setLoading(true);
-    
+
     try {
       const courseData: Omit<Course, 'id' | 'createdAt' | 'updatedAt' | 'rating' | 'studentsCount'> = {
         ...formData,
       };
-      
+
       if (isEditing && existingCourse) {
-        await updateCourse(existingCourse.id, courseData);
+        await updateCourse(existingCourse.id, courseData, modules);
       } else {
-        await addCourse(courseData);
+        await addCourse(courseData, modules);
       }
-      
+
       navigate('/admin/courses');
     } catch (error) {
       setErrors({ general: 'Erro ao salvar curso. Tente novamente.' });


### PR DESCRIPTION
## Summary
- include module list in course create/update payload
- allow fetching course modules for admin editing
- expose course module helpers in API and store

## Testing
- `npm run lint` (fails: 'courses' is assigned a value but never used)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ae724c42208327ac0416ff4bbd8949